### PR TITLE
fix: give extension default name

### DIFF
--- a/cmd/extension.go
+++ b/cmd/extension.go
@@ -325,7 +325,7 @@ func NewCmdExtension(api app.Api, config *tui.Config) *cobra.Command {
 						item.Actions = []tui.Action{
 							{
 								Title: "Install Extension",
-								Cmd:   tui.NewExecCmd(fmt.Sprintf("sunbeam extension install %s", repo.HtmlURL)),
+								Cmd:   tui.NewExecCmd(fmt.Sprintf("sunbeam extension install %s --name %s", repo.HtmlURL, repo.Name)),
 							},
 							{
 								Title: "Open in Browser",


### PR DESCRIPTION
After running `sunbeam extension browse`, the installation of any plugin is unsuccessful, I get a message: "Error: extension name must be specified with --name".